### PR TITLE
change returned metric for googleforms

### DIFF
--- a/refresh-scripts/refresh-googleforms.R
+++ b/refresh-scripts/refresh-googleforms.R
@@ -25,7 +25,7 @@ auth_from_secret("google",
 setup_folders(
   folder_path = folder_path,
   google_entry = "gf_googlesheet",
-  config_file = yaml_file_path, 
+  config_file = yaml_file_path,
   data_name = "googleforms"
 )
 
@@ -38,8 +38,8 @@ yaml <- yaml::read_yaml(yaml_file_path)
 
 if (yaml$data_dest == "google") {
   lapply(form_names, function(form_name) {
-    # Currently this is writing the responses but you could set change it to save the metadata 
-    googlesheets4::write_sheet(google_forms[[form_name]]$answers,
+    # Writing the number of responses (e.g., non-empty rows)
+    googlesheets4::write_sheet(nrow(google_forms[[form_name]]$answers %>% filter(!if_all(everything(), .fns = is.na))),
       ss = yaml$gf_googlesheet,
       sheet = form_name
     )
@@ -48,8 +48,9 @@ if (yaml$data_dest == "google") {
 
 if (yaml$data_dest == "github") {
   lapply(form_names, function(form_name) {
+    # Writing the number of responses (e.g., non-empty rows)
     readr::write_tsv(
-      google_forms[[form_name]]$answers,
+      nrow(google_forms[[form_name]]$answers %>% filter(!if_all(everything(), .fns = is.na))),
       file.path(folder_path, paste0(form_name, ".tsv"))
     )
   })


### PR DESCRIPTION
Adjusted what is returned by metricminer when mining google forms by editing the `refresh-scripts/refresh-googleforms.R` script to return the number of non-empty rows rather than all of the responses.

Tried to do this by first sending the responses (what I assume to be a dataframe) to a filter function to keep rows that aren't all NA's. And then apply an nrow function. 

Haven't been able to test this yet, but if can use a google form that I know I have access to, and add it to the config file or test the relevant ones for this (but I'll need access to the main survey one)