### PR TITLE
update render to use same container as config says

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,5 @@
 # Candace Savonen Dec 2021
-# Updated April 2023
+# Updated Oct 2024
 name: Pull Request
 
 on:
@@ -71,21 +71,21 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     container:
-      image: jhudsl/course_template:main
+      image: ${{needs.yaml-check.outputs.rendering_docker_image}}
     if: ${{needs.yaml-check.outputs.toggle_render_preview == 'yes'}}
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       # Set up git checkout
       - name: Set up git checkout
         run: |
-          git config --system --add safe.directory $GITHUB_WORKSPACE
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
           branch_name='preview-${{ github.event.pull_request.number }}'
           git fetch --all
@@ -102,11 +102,6 @@ jobs:
         id: site
         run: Rscript -e "rmarkdown::render_site()"
 
-      # We may have html files that we want to render to add as links on the pages -these will be stored in a dir called subdir_html
-      - name: Render subdir_html
-        id: subdir_html
-        run: Rscript -e "for (i in list.files(path = './subdir_html', pattern = 'Rmd$', recursive = TRUE, full.names = TRUE)){rmarkdown::render(i)}"
-
       # This checks on the steps before it and makes sure that they completed.
       # If the renders didn't complete we don't want to commit the file changes
       - name: Check on render steps
@@ -115,21 +110,24 @@ jobs:
           echo site status ${{steps.site.outcome}}
           exit 1
 
+      - name: Website preview for download
+        run: zip website-preview.zip docs/* -r
+
       # Commit the rendered website files
-      - name: Commit rendered website files to preview branch
+      - name: Commit rendered website files
         id: commit
         run: |
           branch_name='preview-${{ github.event.pull_request.number }}'
-          git diff origin/main -- '*.html' >/dev/null && changes=true || changes=false
-          echo ::set-output name=changes::$changes
+          git diff origin/main -- docs >/dev/null && changes=true || changes=false
+          echo "changes=$changes" >> $GITHUB_OUTPUT
           git add . --force
           git commit -m 'Render preview' || echo "No changes to commit"
-          git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
+          git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push --force || echo "No changes to commit"
         shell: bash
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v3
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -141,26 +139,31 @@ jobs:
         run: |
           course_name=$(head -n 1 _website.yml | cut -d'"' -f 2| tr " " "-")
           website_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
-          echo ::set-output name=website_link::$website_link
-          echo ::set-output name=time::$(date +'%Y-%m-%d')
-          echo ::set-output name=commit_id::$GITHUB_SHA
+          docs_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/website-preview.zip")
+          echo "zip_link=$docs_link" >> $GITHUB_OUTPUT
+          echo "website_link=$website_link" >> $GITHUB_OUTPUT
+          echo "time=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "commit_id=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo ${{steps.commit.outputs.changes}}
 
       - name: Create or update comment
         if: steps.commit.outputs.changes == 'true'
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Re-rendered previews from the latest commit: See [preview of website here](${{ steps.build-components.outputs.website_link }})
+            :eyes: Quick [preview of website here](${{ steps.build-components.outputs.website_link }}) \*
+            :microscope: Comprehensive [download of the website here](${{ steps.build-components.outputs.zip_link }})
 
-            _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+            \* note not all html features will be properly displayed in the "quick preview" but it will give you a rough idea.
+
+            _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
       - name: No comment if no changes
         if: steps.commit.outputs.changes == 'false'
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
# Description

An open PR (#10) is unable to render the preview and in investigating that further @cansavvy and I discovered that the render preview action was using an old docker image. 

The changes in this PR fix that by using the same image as specified in the config yml file for the dashboard and the render preview.  Additional changes update versions of things and allow for a more comprehensive preview download.