### PR TITLE
Update refresh-citations.R

### DIFF
--- a/.github/workflows/refresh-data.yaml
+++ b/.github/workflows/refresh-data.yaml
@@ -91,6 +91,9 @@ jobs:
           token: ${{ secrets.METRICMINER_GITHUB_PAT }}
 
       - name: Refresh CRAN
+        env:
+          METRICMINER_GOOGLE_ACCESS: ${{ secrets.METRICMINER_GOOGLE_ACCESS }}
+          METRICMINER_GOOGLE_REFRESH: ${{ secrets.METRICMINER_GOOGLE_REFRESH }}
         run: |
           echo ${{needs.yaml-check.outputs.cran_packages}}
           Rscript refresh-scripts/refresh-cran.R
@@ -122,6 +125,9 @@ jobs:
           fetch-depth: 0
 
       - name: Refresh citations
+        env:
+          METRICMINER_GOOGLE_ACCESS: ${{ secrets.METRICMINER_GOOGLE_ACCESS }}
+          METRICMINER_GOOGLE_REFRESH: ${{ secrets.METRICMINER_GOOGLE_REFRESH }}
         run: |
           echo ${{needs.yaml-check.outputs.citation_papers}}
           Rscript refresh-scripts/refresh-citations.R
@@ -189,6 +195,8 @@ jobs:
       - name: Refresh Github
         env:
           METRICMINER_GITHUB_PAT: ${{ secrets.METRICMINER_GITHUB_PAT }}
+          METRICMINER_GOOGLE_ACCESS: ${{ secrets.METRICMINER_GOOGLE_ACCESS }}
+          METRICMINER_GOOGLE_REFRESH: ${{ secrets.METRICMINER_GOOGLE_REFRESH }}
         run: Rscript refresh-scripts/refresh-github.R
 
       - name: Commit Github data

--- a/refresh-scripts/refresh-calendly.R
+++ b/refresh-scripts/refresh-calendly.R
@@ -25,8 +25,6 @@ setup_folders(
   data_name = "calendly"
 )
 
-yaml <- yaml::read_yaml(yaml_file_path)
-
 ### Get calendly data
 user <- get_calendly_user()
 

--- a/refresh-scripts/refresh-calendly.R
+++ b/refresh-scripts/refresh-calendly.R
@@ -15,12 +15,6 @@ folder_path <- file.path("metricminer_data", "calendly")
 yaml_file_path <- file.path(root_dir, "_config_automation.yml")
 yaml <- yaml::read_yaml(yaml_file_path)
 
-# Authorize Google
-auth_from_secret("google",
-                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
-                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
-                 cache = TRUE
-)
 # Authorize Calendly
 auth_from_secret("calendly", token = Sys.getenv("METRICMINER_CALENDLY"))
 
@@ -42,6 +36,14 @@ events <- list_calendly_events(user = user$resource$uri) %>%
   
 
 if (yaml$data_dest == "google") {
+
+  # Authorize Google
+  auth_from_secret("google",
+                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
+                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
+                 cache = TRUE
+  )
+  
   googlesheets4::write_sheet(events,
                              ss = yaml$calendly_googlesheet, 
                              sheet = "calendly"

--- a/refresh-scripts/refresh-citations.R
+++ b/refresh-scripts/refresh-citations.R
@@ -11,16 +11,16 @@ source(file.path(root_dir, "refresh-scripts", "folder-setup.R"))
 
 folder_path <- file.path("metricminer_data", "citations")
 
+# Declare and read in config file
+yaml_file_path <- file.path(root_dir, "_config_automation.yml")
+yaml <- yaml::read_yaml(yaml_file_path)
+
 setup_folders(
   folder_path = folder_path,
   google_entry = "citation_googlesheet",
   config_file = yaml_file_path,
   data_name = "citations"
 )
-
-# Declare and read in config file
-yaml_file_path <- file.path(root_dir, "_config_automation.yml")
-yaml <- yaml::read_yaml(yaml_file_path)
 
 ### Get citation data
 

--- a/refresh-scripts/refresh-citations.R
+++ b/refresh-scripts/refresh-citations.R
@@ -19,7 +19,7 @@ setup_folders(
   folder_path = folder_path,
   google_entry = "citation_googlesheet",
   config_file = yaml_file_path,
-  data_name = "citations"
+  data_name = "citation"
 )
 
 ### Get citation data

--- a/refresh-scripts/refresh-citations.R
+++ b/refresh-scripts/refresh-citations.R
@@ -11,24 +11,15 @@ source(file.path(root_dir, "refresh-scripts", "folder-setup.R"))
 
 folder_path <- file.path("metricminer_data", "citations")
 
-# Declare and read in config file
-yaml_file_path <- file.path(root_dir, "_config_automation.yml")
-yaml <- yaml::read_yaml(yaml_file_path)
-
-# Authorize Google
-auth_from_secret("google",
-                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
-                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
-                 cache = TRUE
-)
-
 setup_folders(
   folder_path = folder_path,
   google_entry = "citation_googlesheet",
   config_file = yaml_file_path,
-  data_name = "citation"
+  data_name = "citations"
 )
 
+# Declare and read in config file
+yaml_file_path <- file.path(root_dir, "_config_automation.yml")
 yaml <- yaml::read_yaml(yaml_file_path)
 
 ### Get citation data
@@ -41,8 +32,16 @@ all_papers <- lapply(yaml$citation_papers, function(paper) {
 all_papers <- dplyr::bind_rows(all_papers)
 
 
-
+#store citation counts
 if (yaml$data_dest == "google") {
+
+  # Authorize Google
+  auth_from_secret("google",
+                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
+                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
+                 cache = TRUE
+  )
+  
   googlesheets4::write_sheet(all_papers,
                              ss = yaml$citation_googlesheet,
                              sheet = "citations"

--- a/refresh-scripts/refresh-cran.R
+++ b/refresh-scripts/refresh-cran.R
@@ -16,22 +16,12 @@ folder_path <- file.path("metricminer_data", "cran")
 yaml_file_path <- file.path(root_dir, "_config_automation.yml")
 yaml <- yaml::read_yaml(yaml_file_path)
 
-# Authorize Google
-auth_from_secret("google",
-                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
-                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
-                 cache = TRUE
-)
-
 setup_folders(
   folder_path = folder_path,
   google_entry = "cran_googlesheet",
   config_file = yaml_file_path, 
   data_name = "cran"
 )
-
-yaml <- yaml::read_yaml(yaml_file_path)
-
 
 ### Get the CRAN data
 cran_stats <- cranlogs::cran_downloads(
@@ -44,6 +34,13 @@ cran_stats <- cranlogs::cran_downloads(
 
 
 if (yaml$data_dest == "google") {
+  # Authorize Google
+  auth_from_secret("google",
+                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
+                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
+                 cache = TRUE
+  )
+  
   googlesheets4::write_sheet(cran_stats,
                              ss = yaml$cran_googlesheet,
                              sheet = "cran"

--- a/refresh-scripts/refresh-ga.R
+++ b/refresh-scripts/refresh-ga.R
@@ -30,8 +30,6 @@ setup_folders(
   data_name = "ga"
 )
 
-yaml <- yaml::read_yaml(yaml_file_path)
-
 # Get the metrics
 metrics <- get_multiple_ga_metrics(property_ids = yaml$ga_property_ids, stats_type = c("metrics", "dimensions", "link_clicks"))
 

--- a/refresh-scripts/refresh-github.R
+++ b/refresh-scripts/refresh-github.R
@@ -15,12 +15,6 @@ folder_path <- file.path("metricminer_data", "github")
 yaml_file_path <- file.path(root_dir, "_config_automation.yml")
 yaml <- yaml::read_yaml(yaml_file_path)
 
-# Authorize Google
-auth_from_secret("google",
-                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
-                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
-                 cache = TRUE
-)
 # Authorize GitHub
 auth_from_secret("github", token = Sys.getenv("METRICMINER_GITHUB_PAT"))
 
@@ -35,17 +29,23 @@ setup_folders(
   data_name = "github"
 )
 
-yaml <- yaml::read_yaml(yaml_file_path)
-
 if (yaml$data_dest == "google") {
-    googlesheets4::write_sheet(gh_metrics,
+
+  # Authorize Google
+  auth_from_secret("google",
+                 refresh_token = Sys.getenv("METRICMINER_GOOGLE_REFRESH"),
+                 access_token = Sys.getenv("METRICMINER_GOOGLE_ACCESS"),
+                 cache = TRUE
+  )
+  
+  googlesheets4::write_sheet(gh_metrics,
                                ss = yaml$gh_googlesheet,
                                sheet = "overall_stats"
-    )
-    googlesheets4::write_sheet(gh_timecourse,
+  )
+  googlesheets4::write_sheet(gh_timecourse,
                                ss = yaml$gh_googlesheet,
                                sheet = "timecourse"
-    )
+  )
 }
 
 if (yaml$data_dest == "github") {

--- a/refresh-scripts/refresh-googleforms.R
+++ b/refresh-scripts/refresh-googleforms.R
@@ -35,7 +35,6 @@ setup_folders(
 google_forms <- get_multiple_forms(form_ids = yaml$google_forms)
 form_names <- names(google_forms)
 
-yaml <- yaml::read_yaml(yaml_file_path)
 
 if (yaml$data_dest == "google") {
   lapply(form_names, function(form_name) {

--- a/refresh-scripts/refresh-slido.R
+++ b/refresh-scripts/refresh-slido.R
@@ -29,9 +29,6 @@ setup_folders(
   data_name = "slido"
 )
 
-yaml <- yaml::read_yaml(yaml_file_path)
-
-
 ### Get Slido data
 drive_id <- "https://drive.google.com/drive/u/0/folders/1XWXHHyj32Uw_UyaUJrqp6S--hHnM0-7l"
 slido_data <- get_slido_files(drive_id)

--- a/refresh-scripts/refresh-youtube.R
+++ b/refresh-scripts/refresh-youtube.R
@@ -29,8 +29,6 @@ setup_folders(
   data_name = "youtube"
 )
 
-yaml <- yaml::read_yaml(yaml_file_path)
-
 ### Get Youtube data
 youtube_metrics <- lapply(yaml$video_ids, get_youtube_video_stats) 
 names(youtube_metrics) <- yaml$video_ids


### PR DESCRIPTION
Was running into an error on refresh data where citations was failing because the google authorization was failing because the refresh-script didn't have access to the google creds (which honestly it didn't need because it wasn't fetching google data or writing it out). This PR originally (in the commit 55eee8c) addressed this problem by moving the authentication step within a conditional that wasn't evaluating to true because of how I've got my _config_automation.yml setup. 

Later commits did this moving within the conditional for any refresh data script where the authorization is only necessary to write out data (if google is location of choice instead of github) and not to read in data (slido, google analytics, google forms, and youtube all need it to read in data; citations, calendly, cran, and github do not need google auth to read in data). Secondly, within the refresh data action, I now provide the google creds to every refresh script in case it's needed for writing out data. 

Additionally, I noticed all refresh scripts were reading in the config yaml twice, so I deduplicated that