### PR TITLE
Add collection status

### DIFF
--- a/OCS_CollectionStatus_Table.Rmd
+++ b/OCS_CollectionStatus_Table.Rmd
@@ -22,7 +22,7 @@
   </tr> ends row
 -->
   <tr>
-    <th>Bio-OCS: Single Cell</th>
+    <th>Single Cell</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell" target="_blank">opencasestudies/bio-ocs-et-single-cell</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-single-cell/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-single-cell" alt="Open Issues"></a></th>
@@ -31,7 +31,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-et-single-cell" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Machine Learning</th>
+    <th>Machine Learning</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion" target="_blank">opencasestudies/bio-ocs-et-ai-diffusion</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open Issues"></a></th>
@@ -40,7 +40,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-et-ai-diffusion" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Spatial Transcriptomics (Expression)</th>
+    <th>Spatial Transcriptomics</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression" target="_blank">opencasestudies/bio-ocs-et-spatial-expression</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-expression" alt="Open Issues"></a></th>
@@ -49,7 +49,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-expression" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Matrix Factorization and Latent Variables (Spatial Data)</th>
+    <th>Matrix Factorization and Latent Variables</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable" target="_blank">opencasestudies/bio-ocs-et-spatial-latent-variable</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open Issues"></a></th>
@@ -58,7 +58,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-latent-variable" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Temporal Data Analysis</th>
+    <th>Temporal Data Analysis</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal" target="_blank">opencasestudies/bio-ocs-et-temporal</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-temporal/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-temporal" alt="Open Issues"></a></th>
@@ -67,7 +67,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-et-temporal" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Biocontainers</th>
+    <th>Biocontainers</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers" target="_blank">opencasestudies/bio-ocs-bp-biocontainers</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-biocontainers" alt="Open Issues"></a></th>
@@ -76,7 +76,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-bp-biocontainers" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Version Control and Code Review</th>
+    <th>Version Control and Code Review</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control" target="_blank">opencasestudies/bio-ocs-bp-version-control</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-version-control/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-version-control" alt="Open Issues"></a></th>
@@ -85,7 +85,7 @@
     <th><a href="https://opencasestudies.org/bio-ocs-bp-version-control" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Bio-OCS: Big Data</th>
+    <th>Big Data</th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data" target="_blank">opencasestudies/bio-ocs-bp-big-data</a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-big-data/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-big-data" alt="Open Issues"></a></th>

--- a/OCS_CollectionStatus_Table.Rmd
+++ b/OCS_CollectionStatus_Table.Rmd
@@ -18,7 +18,7 @@
     <th><a href="https://github.com/opencasestudies/{REPO_NAME}/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/{REPO_NAME}" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/{REPO_NAME}/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/{REPO_NAME}" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/{REPO_NAME}/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/{REPO_NAME}" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/{REPO_NAME}" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/{REPO_NAME}" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr> ends row
 -->
   <tr>
@@ -28,7 +28,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-single-cell" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-single-cell" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-single-cell" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-single-cell" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-single-cell" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Machine Learning</th>
@@ -37,7 +37,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-ai-diffusion" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-ai-diffusion" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-ai-diffusion" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Spatial Transcriptomics (Expression)</th>
@@ -46,7 +46,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-expression" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-spatial-expression" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-spatial-expression" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-expression" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-expression" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Matrix Factorization and Latent Variables (Spatial Data)</th>
@@ -55,7 +55,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-latent-variable" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-latent-variable" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Temporal Data Analysis</th>
@@ -64,7 +64,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-temporal" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-temporal" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-temporal" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-temporal" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-temporal" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Biocontainers</th>
@@ -73,7 +73,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-biocontainers" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-biocontainers" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-biocontainers" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-bp-biocontainers" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-bp-biocontainers" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Version Control and Code Review</th>
@@ -82,7 +82,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-version-control" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-version-control" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-version-control" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-bp-version-control" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-bp-version-control" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Bio-OCS: Big Data</th>
@@ -91,7 +91,7 @@
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-big-data" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-big-data" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-big-data" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-bp-big-data" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-bp-big-data" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Quarto Template</th>
@@ -100,6 +100,6 @@
     <th><a href="https://github.com/opencasestudies/ocs-template-quarto/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-template-quarto" alt="Open Issues"></a></th>
     <th><a href="https://github.com/opencasestudies/ocs-template-quarto/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-template-quarto" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/opencasestudies/ocs-template-quarto/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-template-quarto" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/ocs-template-quarto" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+    <th><a href="https://opencasestudies.org/ocs-template-quarto" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
 </table>

--- a/OCS_CollectionStatus_Table.Rmd
+++ b/OCS_CollectionStatus_Table.Rmd
@@ -1,5 +1,12 @@
 # Status of Book Repositories in the Bio-OCS Collection
 
+<style>
+/* Change font size for all table data cells (td) and headers (th) */
+td, th {
+  font-size: 10px;
+}
+</style>
+
 <table>
   <tr>
     <th>Case Study Topic</th>

--- a/OCS_CollectionStatus_Table.Rmd
+++ b/OCS_CollectionStatus_Table.Rmd
@@ -30,75 +30,75 @@ td, th {
 -->
   <tr>
     <th>Single Cell</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell" target="_blank">opencasestudies/bio-ocs-et-single-cell</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-single-cell/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-single-cell" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-single-cell" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-single-cell" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-single-cell" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-single-cell" target="_blank">opencasestudies/ocs-bio-single-cell</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-single-cell/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-single-cell/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-single-cell/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-single-cell" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-single-cell/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-single-cell" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-single-cell/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-single-cell" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-single-cell" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
-    <th>Machine Learning</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion" target="_blank">opencasestudies/bio-ocs-et-ai-diffusion</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-ai-diffusion" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-ai-diffusion" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th>Deep Learning</th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-ai-deep-learning" target="_blank">opencasestudies/ocs-bio-ai-deep-learning</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-ai-deep-learning/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-ai-deep-learning/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-ai-deep-learning/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-ai-deep-learning" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-ai-deep-learning/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-ai-deep-learning" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-ai-deep-learning/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-ai-deep-learning" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-ai-deep-learning" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Spatial Transcriptomics</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression" target="_blank">opencasestudies/bio-ocs-et-spatial-expression</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-expression" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-spatial-expression" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-spatial-expression" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-expression" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-spatial-transcriptomics" target="_blank">opencasestudies/ocs-bio-spatial-transcriptomics</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-spatial-transcriptomics/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-spatial-transcriptomics/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-spatial-transcriptomics/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-spatial-transcriptomics" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-spatial-transcriptomics/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-spatial-transcriptomics" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-spatial-transcriptomics/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-spatial-transcriptomics" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-spatial-transcriptomics" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Matrix Factorization and Latent Variables</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable" target="_blank">opencasestudies/bio-ocs-et-spatial-latent-variable</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-latent-variable" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-latent-variable" target="_blank">opencasestudies/ocs-bio-latent-variable</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-latent-variable/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-latent-variable/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-latent-variable/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-latent-variable" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-latent-variable/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-latent-variable" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-latent-variable/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-latent-variable" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-latent-variable" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Temporal Data Analysis</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal" target="_blank">opencasestudies/bio-ocs-et-temporal</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-temporal/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-temporal" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-temporal" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-temporal" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-et-temporal" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-temporal" target="_blank">opencasestudies/ocs-bio-temporal</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-temporal/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-temporal/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-temporal/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-temporal" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-temporal/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-temporal" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-temporal/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-temporal" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-temporal" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Biocontainers</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers" target="_blank">opencasestudies/bio-ocs-bp-biocontainers</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-biocontainers" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-biocontainers" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-biocontainers" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-bp-biocontainers" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-biocontainers" target="_blank">opencasestudies/ocs-bio-biocontainers</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-biocontainers/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-biocontainers/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-biocontainers/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-biocontainers" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-biocontainers/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-biocontainers" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-biocontainers/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-biocontainers" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-biocontainers" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Version Control and Code Review</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control" target="_blank">opencasestudies/bio-ocs-bp-version-control</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-version-control/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-version-control" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-version-control" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-version-control" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-bp-version-control" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-version-control" target="_blank">opencasestudies/ocs-bio-version-control</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-version-control/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-version-control/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-version-control/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-version-control" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-version-control/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-version-control" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-version-control/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-version-control" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-version-control" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Big Data</th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data" target="_blank">opencasestudies/bio-ocs-bp-big-data</a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-big-data/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-big-data" alt="Open Issues"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-big-data" alt="GitHub Branches"></a></th>
-    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-big-data" alt="Open PRs"></a></th>
-    <th><a href="https://opencasestudies.org/bio-ocs-bp-big-data" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-big-data" target="_blank">opencasestudies/ocs-bio-big-data</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-big-data/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-bio-big-data/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-big-data/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-bio-big-data" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-big-data/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-bio-big-data" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-bio-big-data/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-bio-big-data" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-bio-big-data" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
   </tr>
   <tr>
     <th>Quarto Template</th>

--- a/OCS_CollectionStatus_Table.Rmd
+++ b/OCS_CollectionStatus_Table.Rmd
@@ -1,0 +1,105 @@
+# Status of Book Repositories in the Bio-OCS Collection
+
+<table>
+  <tr>
+    <th>Case Study Topic</th>
+    <th>Repository name</th>
+    <th>Render Status</th>
+    <th>Number of Open Issues</th>
+    <th>Number of Branches</th>
+    <th>Number of Open PRs</th>
+    <th>Website up?</th>
+  </tr>
+<!-- Comment showing row format. Note private repos will not be accessible with badgen
+  <tr> new row
+    <th>{Case Study Topic}</th>
+    <th><a href="https://github.com/opencasestudies/{REPO_NAME}" target="_blank">opencasestudies/{REPO_NAME}</a></th>
+    <th><a href="https://github.com/opencasestudies/{REPO_NAME}/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/{REPO_NAME}/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/{REPO_NAME}/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/{REPO_NAME}" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/{REPO_NAME}/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/{REPO_NAME}" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/{REPO_NAME}/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/{REPO_NAME}" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/{REPO_NAME}" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr> ends row
+-->
+  <tr>
+    <th>Bio-OCS: Single Cell</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell" target="_blank">opencasestudies/bio-ocs-et-single-cell</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-single-cell/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-single-cell" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-single-cell" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-single-cell/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-single-cell" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-single-cell" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Machine Learning</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion" target="_blank">opencasestudies/bio-ocs-et-ai-diffusion</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-ai-diffusion" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-ai-diffusion/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-ai-diffusion" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-ai-diffusion" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Spatial Transcriptomics (Expression)</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression" target="_blank">opencasestudies/bio-ocs-et-spatial-expression</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-expression" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-spatial-expression" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-expression/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-spatial-expression" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-expression" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Matrix Factorization and Latent Variables (Spatial Data)</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable" target="_blank">opencasestudies/bio-ocs-et-spatial-latent-variable</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-spatial-latent-variable/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-spatial-latent-variable" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-spatial-latent-variable" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Temporal Data Analysis</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal" target="_blank">opencasestudies/bio-ocs-et-temporal</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-et-temporal/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-et-temporal" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-et-temporal" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-et-temporal/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-et-temporal" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-et-temporal" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Biocontainers</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers" target="_blank">opencasestudies/bio-ocs-bp-biocontainers</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-biocontainers" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-biocontainers" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-biocontainers/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-biocontainers" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-bp-biocontainers" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Version Control and Code Review</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control" target="_blank">opencasestudies/bio-ocs-bp-version-control</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-version-control/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-version-control" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-version-control" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-version-control/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-version-control" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-bp-version-control" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Bio-OCS: Big Data</th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data" target="_blank">opencasestudies/bio-ocs-bp-big-data</a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/bio-ocs-bp-big-data/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/bio-ocs-bp-big-data" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/bio-ocs-bp-big-data" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/bio-ocs-bp-big-data/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/bio-ocs-bp-big-data" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/bio-ocs-bp-big-data" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+  <tr>
+    <th>Quarto Template</th>
+    <th><a href="https://github.com/opencasestudies/ocs-template-quarto" target="_blank">opencasestudies/ocs-template-quarto</a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-template-quarto/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/opencasestudies/ocs-template-quarto/actions/workflows/render-all.yml/badge.svg" alt="Render output"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-template-quarto/issues?q=is%3Aopen" target="_blank"><img src="https://img.shields.io/github/issues/opencasestudies/ocs-template-quarto" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-template-quarto/branches" target="_blank"> <img src="https://badgen.net/github/branches/opencasestudies/ocs-template-quarto" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/opencasestudies/ocs-template-quarto/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/opencasestudies/ocs-template-quarto" alt="Open PRs"></a></th>
+    <th><a href="https://opencasestudies.org/ocs-template-quarto" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr>
+</table>

--- a/_site.yml
+++ b/_site.yml
@@ -23,7 +23,7 @@ navbar:
     icon: fa-play
   - text: OCS Collection
     href: OCS_CollectionStatus_Table.html
-    icon: fa-books
+    icon: fa-table
 
 output:
   html_document:

--- a/_site.yml
+++ b/_site.yml
@@ -21,6 +21,9 @@ navbar:
   - text: Youtube
     href: youtube.html
     icon: fa-play
+  - text: OCS Collection
+    href: OCS_CollectionStatus_Table.html
+    icon: fa-books
 
 output:
   html_document:

--- a/resources/ignore-urls.txt
+++ b/resources/ignore-urls.txt
@@ -3,3 +3,9 @@ https://docs.google.com/forms/u/1/d/<GOOGLE_FORM_ID_HERE>/edit?usp=drive_web
 https://www.youtube.com/watch?v=<YOUTUBE_VIDEO_ID_HERE>
 https://drive.google.com/drive/u/1/folders/<SOME_FOLDER_ID_HERE>
 https://analytics.google.com/analytics/web/?authuser=1#/p<PROPERTY_ID_HERE>/reports/home
+https://github.com/opencasestudies/{REPO_NAME}
+https://github.com/opencasestudies/{REPO_NAME}/actions/workflows/render-all.yml
+https://github.com/opencasestudies/{REPO_NAME}/issues?q=is%3Aopen
+https://github.com/opencasestudies/{REPO_NAME}/branches
+https://github.com/opencasestudies/{REPO_NAME}/pulls?q=is%3Aopen
+https://opencasestudies.org/{REPO_NAME}


### PR DESCRIPTION
# Description

Adding a tab that lists books within the OCS collection and shows the status of those repos (number of open issues, number of open PRs, number of branches, if the GitHub Pages website is up or down). 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Used the AnVIL Collection version as an example: https://github.com/jhudsl/AnVIL_Template/blob/main/AnVIL_Template_CollectionStatus_Table.Rmd

Will also check the render preview in this PR